### PR TITLE
handle multiple predictions from SpliceAI for a single variant

### DIFF
--- a/absplice/utils.py
+++ b/absplice/utils.py
@@ -129,13 +129,14 @@ def read_spliceai_vcf(path):
                 'donor_loss_position']
     rows = list()
     for variant in MultiSampleVCF(path):
-        row = variant.source.INFO.get('SpliceAI')
-        results = row.split('|')[1:]
-        scores = np.array(list(map(float, results[1:])))
-        spliceai_info = [results[0], scores[:4].max(), *scores]
-        rows.append({
-            **{'variant': str(variant)}, 
-            **dict(zip(columns, spliceai_info))})
+        row_all = variant.source.INFO.get('SpliceAI')
+        for row in row_all.split(','):
+            results = row.split('|')[1:]
+            scores = np.array(list(map(float, results[1:])))
+            spliceai_info = [results[0], scores[:4].max(), *scores]
+            rows.append({
+                **{'variant': str(variant)}, 
+                **dict(zip(columns, spliceai_info))})
     df = pd.DataFrame(rows)
         
     for col in df.columns:


### PR DESCRIPTION
Sometimes SpliceAI returns multiple predictions if a variant affects multiple genes. This creates one entry per prediction (rather than one per variant) in the SpliceAI DF