### PR TITLE
add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include absplice/precomputed *


### PR DESCRIPTION
@WagnerNils I tested the change and at least on my system it works:
```bash
/home/hoelzlwimmerf/Projects/absplice> tree /opt/anaconda/envs/absplice/lib/python3.9/site-packages/absplice
/opt/anaconda/envs/absplice/lib/python3.9/site-packages/absplice
├── __init__.py
├── __pycache__
│   ├── __init__.cpython-39.pyc
│   ├── cat_dataloader.cpython-39.pyc
│   ├── dataloader.cpython-39.pyc
│   ├── ensemble.cpython-39.pyc
│   ├── model.cpython-39.pyc
│   ├── result.cpython-39.pyc
│   ├── spliceai_rocksdb_download.cpython-39.pyc
│   └── utils.cpython-39.pyc
├── cat_dataloader.py
├── dataloader.py
├── ensemble.py
├── model.py
├── precomputed
│   ├── ABSPLICE_DNA_with_CADD_Splice.dict.pkl
│   ├── ABSPLICE_DNA_with_CADD_Splice.onnx
│   ├── ABSPLICE_DNA_with_CADD_Splice.pkl
│   ├── AbSplice_DNA.dict.pkl
│   ├── AbSplice_DNA.onnx
│   ├── AbSplice_DNA.onnx.bak
│   ├── AbSplice_DNA.pkl
│   ├── AbSplice_RNA.dict.pkl
│   ├── AbSplice_RNA.onnx
│   ├── AbSplice_RNA.onnx.bak
│   ├── AbSplice_RNA.pkl
│   ├── AbSplice_onnx.zip
│   ├── GENE_MAP.tsv.gz
│   └── GENE_TPM.csv.gz
├── result.py
├── spliceai_rocksdb_download.py
└── utils.py

3 directories, 30 files
```