### PR TITLE
Update environment_spliceai_rocksdb.yaml to fix numpy bug

### DIFF
--- a/example/envs/environment_spliceai_rocksdb.yaml
+++ b/example/envs/environment_spliceai_rocksdb.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.6
+  - numpy==1.23.4
   - python-rocksdb>=0.7
   - rocksdb
   - tensorflow-gpu>=2.4


### PR DESCRIPTION
This simple adjustment of the conda env config that fixes the numpy version should fix the bug described in https://github.com/gagneurlab/absplice/issues/39.